### PR TITLE
Remember referrer link after login

### DIFF
--- a/templates/login.html.j2
+++ b/templates/login.html.j2
@@ -81,6 +81,10 @@
                      setCookie(`${mgrApiCookieName}-userid`, apiKey.user_id);
                      setCookie(`${mgrApiCookieName}-api_key_id`, apiKey.id);
                      setLoggedinUsername(qparams.get("mgr"), this.username);
+                     if (document.referrer && document.referrer != "") {
+                         location.href = document.referrer;
+                         return;
+                     }
                      location.href = `/pools?mgr=${qparams.get("mgr")}`;
                  } catch (error) {
                      this.error = error;


### PR DESCRIPTION
If someone shares a link with others, then it will redirect to login page. Once logged in, then it was not redirecting to the page that was opened earlier.

With this PR, login page will redirect to referrer page.

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.tech>